### PR TITLE
Accessible links (replace `click here`)

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@ scripts:
 <p>This page implements a <em>completely private</em> lookup tool for domain names, IP addresses and Autonomous System Numbers (ASNs). Only the relevant registry sees your query: your browser will directly connect to the registry's RDAP server using an encrypted HTTPS connection to protect the confidentiality of your query. If the "Follow referral to registrar's RDAP record" checkbox is checked, then the sponsoring registrar may also see your query (if the registry provides a referral).</p>
 
 <ul>
-  <li><a href="https://about.rdap.org" target="_new">Click here</a> for more information about what RDAP is and how it differs from traditional Whois.</li>
+  <li><a href="https://about.rdap.org" target="_new">Read about RDAP</a> and how it differs from traditional Whois.</li>
   <li>All generic TLDs now support RDAP, but only a few ccTLDs have deployed RDAP so far. To see which TLDs support RDAP, <a href="https://deployment.rdap.org" target="_new">click here</a>.</li>
   <li>There is (currently) no bootstrap registry for ICANN-accredited registrars; instead these queries are sent to <a href="https://about.rdap.org/#additional" target="_new">the registrars.rdap.org server.</a>.</li>
   <li>To submit feedback, <a href="mailto:feedback@rdap.org">click here</a>. Please contact the relevant registry or registrar if you have an issue with the content of an RDAP response.</li>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ scripts:
   <li>There is (currently) no bootstrap registry for ICANN-accredited registrars; instead these queries are sent to <a href="https://about.rdap.org/#additional" target="_new">the registrars.rdap.org server.</a>.</li>
   <li>You can <a href="mailto:feedback@rdap.org">submit feedback about RDAP</a>. Please contact the relevant registry or registrar if you have an issue with the content of an RDAP response.</li>
   <li>Found a problem with an RDAP response? You can use the <a href="https://validator.rdap.org">RDAP Validator</a> to check for issues.</li>
-  <li>This tool is Free Software; for the license, <a href="LICENSE">click here</a>. To fork a copy of the git repository, <a rel="noopener" target="_new" href="https://github.com/rdap-org/client.rdap.org">click here</a>.</li>
+  <li>This tool is Free Software; see the <a href="LICENSE">license</a>. To fork a copy of the git repository, <a rel="noopener" target="_new" href="https://github.com/rdap-org/client.rdap.org">click here</a>.</li>
   <li>This page uses <a rel="noopener" target="_new" href="https://github.com/whitequark/ipaddr.js/">ipaddr.js</a> by <a rel="noopener" target="_new" href="https://whitequark.org/">whitequark</a>, and <a rel="noopener" target="_new" href="https://github.com/mathiasbynens/punycode.js">punycode.js</a> by <a rel="noopener" target="_new" href="https://mathiasbynens.be/">Mathias Bynens</a>.</li>
 </ul>
 

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ scripts:
 
 <ul>
   <li><a href="https://about.rdap.org" target="_new">Read about RDAP</a> and how it differs from traditional Whois.</li>
-  <li>All generic TLDs now support RDAP, but only a few ccTLDs have deployed RDAP so far. To see which TLDs support RDAP, <a href="https://deployment.rdap.org" target="_new">click here</a>.</li>
+  <li>All generic TLDs now support RDAP, but only a <a href="https://deployment.rdap.org" target="_new">few ccTLDs have deployed RDAP</a> so far.</li>
   <li>There is (currently) no bootstrap registry for ICANN-accredited registrars; instead these queries are sent to <a href="https://about.rdap.org/#additional" target="_new">the registrars.rdap.org server.</a>.</li>
   <li>To submit feedback, <a href="mailto:feedback@rdap.org">click here</a>. Please contact the relevant registry or registrar if you have an issue with the content of an RDAP response.</li>
   <li>Found a problem with an RDAP response? You can use the <a href="https://validator.rdap.org">RDAP Validator</a> to check for issues.</li>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@ scripts:
   <li>There is (currently) no bootstrap registry for ICANN-accredited registrars; instead these queries are sent to <a href="https://about.rdap.org/#additional" target="_new">the registrars.rdap.org server.</a>.</li>
   <li>You can <a href="mailto:feedback@rdap.org">submit feedback about RDAP</a>. Please contact the relevant registry or registrar if you have an issue with the content of an RDAP response.</li>
   <li>Found a problem with an RDAP response? You can use the <a href="https://validator.rdap.org">RDAP Validator</a> to check for issues.</li>
-  <li>This tool is Free Software; see the <a href="LICENSE">license</a>. To fork a copy of the git repository, <a rel="noopener" target="_new" href="https://github.com/rdap-org/client.rdap.org">click here</a>.</li>
+  <li>This tool is Free Software; see the <a href="LICENSE">license</a>. You can fork a copy of the <a rel="noopener" target="_new" href="https://github.com/rdap-org/client.rdap.org">git repository</a>.</li>
   <li>This page uses <a rel="noopener" target="_new" href="https://github.com/whitequark/ipaddr.js/">ipaddr.js</a> by <a rel="noopener" target="_new" href="https://whitequark.org/">whitequark</a>, and <a rel="noopener" target="_new" href="https://github.com/mathiasbynens/punycode.js">punycode.js</a> by <a rel="noopener" target="_new" href="https://mathiasbynens.be/">Mathias Bynens</a>.</li>
 </ul>
 

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@ scripts:
   <li><a href="https://about.rdap.org" target="_new">Read about RDAP</a> and how it differs from traditional Whois.</li>
   <li>All generic TLDs now support RDAP, but only a <a href="https://deployment.rdap.org" target="_new">few ccTLDs have deployed RDAP</a> so far.</li>
   <li>There is (currently) no bootstrap registry for ICANN-accredited registrars; instead these queries are sent to <a href="https://about.rdap.org/#additional" target="_new">the registrars.rdap.org server.</a>.</li>
-  <li>To submit feedback, <a href="mailto:feedback@rdap.org">click here</a>. Please contact the relevant registry or registrar if you have an issue with the content of an RDAP response.</li>
+  <li>You can <a href="mailto:feedback@rdap.org">submit feedback about RDAP</a>. Please contact the relevant registry or registrar if you have an issue with the content of an RDAP response.</li>
   <li>Found a problem with an RDAP response? You can use the <a href="https://validator.rdap.org">RDAP Validator</a> to check for issues.</li>
   <li>This tool is Free Software; for the license, <a href="LICENSE">click here</a>. To fork a copy of the git repository, <a rel="noopener" target="_new" href="https://github.com/rdap-org/client.rdap.org">click here</a>.</li>
   <li>This page uses <a rel="noopener" target="_new" href="https://github.com/whitequark/ipaddr.js/">ipaddr.js</a> by <a rel="noopener" target="_new" href="https://whitequark.org/">whitequark</a>, and <a rel="noopener" target="_new" href="https://github.com/mathiasbynens/punycode.js">punycode.js</a> by <a rel="noopener" target="_new" href="https://mathiasbynens.be/">Mathias Bynens</a>.</li>


### PR DESCRIPTION
For more information, see:

* https://www.w3.org/QA/Tips/noClickHere
* https://webaim.org/techniques/hypertext/link_text
* https://granicus.com/blog/why-click-here-links-are-bad/
* https://heyoka.medium.com/dont-use-click-here-f32f445d1021
